### PR TITLE
Typo fix - Android recovery bug

### DIFF
--- a/board/embeddedartists/mx6qea-com/mx6qea-com.c
+++ b/board/embeddedartists/mx6qea-com/mx6qea-com.c
@@ -1743,7 +1743,7 @@ void board_recovery_setup(void)
 	case MMC4_BOOT:
 		if (!getenv("bootcmd_android_recovery"))
 			setenv("bootcmd_android_recovery",
-				"booti mmc2 recovery");
+				"boota mmc2 recovery");
 		break;
 #endif /*CONFIG_FASTBOOT_STORAGE_MMC*/
 	default:


### PR DESCRIPTION
* Fixed a typo that caused booting to recovery from Android OS to get
stuck in the booloader